### PR TITLE
Let a processing command return false to indicate that nothing should change

### DIFF
--- a/src/AppBundle/Command/Processing/AbstractProcessingCmd.php
+++ b/src/AppBundle/Command/Processing/AbstractProcessingCmd.php
@@ -207,12 +207,14 @@ abstract class AbstractProcessingCmd extends ContainerAwareCommand
                 continue;
             }
 
-            if ($result) {
+            if ($result === true) {
                 $deposit->setState($this->nextState());
                 $deposit->addToProcessingLog($this->successLogMessage());
-            } else {
+            } elseif($result === false) {
                 $deposit->setState($this->errorState());
                 $deposit->addToProcessingLog($this->failureLogMessage());
+            } elseif($result === null) {
+                // dunno, do nothing I guess.
             }
             $this->em->flush($deposit);
         }

--- a/src/AppBundle/Command/Processing/StatusCommand.php
+++ b/src/AppBundle/Command/Processing/StatusCommand.php
@@ -79,7 +79,7 @@ class StatusCommand extends AbstractProcessingCmd
      *
      * @param Deposit $deposit
      *
-     * @return type
+     * @return boolean|null
      */
     protected function processDeposit(Deposit $deposit)
     {
@@ -93,7 +93,10 @@ class StatusCommand extends AbstractProcessingCmd
             unlink($this->filePaths->getHarvestFile($deposit));
         }
 
-        return $status === 'agreement';
+        if($status === 'agreement') {
+            return true;
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION

So for example, if a deposit status isn't yet agreement, but there were no errors checking the deposit status, don't toss an error.